### PR TITLE
wasm2c: initialize wasm_rt_call_stack_depth in init()

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1367,6 +1367,7 @@ void CWriter::WriteInit() {
   Write("init_globals(module_instance);", Newline());
   Write("init_memory(module_instance);", Newline());
   Write("init_table(module_instance);", Newline());
+  Write("module_instance->wasm_rt_call_stack_depth = 0;", Newline());
   for (Var* var : module_->starts) {
     Write(ExternalRef(module_->GetFunc(*var)->name), "(module_instance);",
           Newline());


### PR DESCRIPTION
Now that the wasm_rt_call_stack_depth variable has become a struct member (instead of a static global), I think it needs to be initialized explicitly or else it could have uninitialized/random contents on use. Maybe there is a more elegant way to do this?